### PR TITLE
feat: observability — Langfuse + AgentOps integration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -8,9 +8,22 @@ USER_DISPLAY_NAME=YourName
 # Database (override for production)
 DATABASE_URL=sqlite+aiosqlite:///./data/herd.db
 
-# Langfuse
-LANGFUSE_PUBLIC_KEY=pk-...
-LANGFUSE_SECRET_KEY=sk-...
+# ── Langfuse (self-hosted via docker-compose) ──────────────────────────────
+# 1. Run: docker compose up langfuse langfuse-db
+# 2. Open http://localhost:3002 → create account → Settings → API Keys
+# 3. Paste keys below
+LANGFUSE_PUBLIC_KEY=pk-lf-...
+LANGFUSE_SECRET_KEY=sk-lf-...
+LANGFUSE_HOST=http://localhost:3002
+
+# Langfuse docker-compose internal secrets (change before production)
+LANGFUSE_NEXTAUTH_SECRET=herd-langfuse-secret-change-me
+LANGFUSE_SALT=herd-langfuse-salt-change-me
+
+# ── AgentOps (cloud — https://app.agentops.ai) ────────────────────────────
+# 1. Sign up at https://app.agentops.ai (free tier)
+# 2. Create a project → copy API key below
+AGENTOPS_API_KEY=ao-...
 
 # GrowthBook
 GROWTHBOOK_CLIENT_KEY=sdk-...

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,17 @@
 version: "3.9"
 
+# ─────────────────────────────────────────────
+#  Herd AI — Full Stack
+#  Services:
+#    api        FastAPI backend         :8000
+#    dashboard  Next.js Mission Control :3001
+#    langfuse   LLM observability UI    :3002
+#    langfuse-db PostgreSQL for Langfuse
+# ─────────────────────────────────────────────
+
 services:
+
+  # ── Herd API ──────────────────────────────
   api:
     build:
       context: .
@@ -10,17 +21,63 @@ services:
     volumes:
       - ./data:/app/data
       - ./config.yaml:/app/config.yaml
+    env_file:
+      - .env
     environment:
       - PYTHONUNBUFFERED=1
+      - LANGFUSE_HOST=http://langfuse:3000
     command: uvicorn src.api.app:app --host 0.0.0.0 --port 8000
+    depends_on:
+      langfuse:
+        condition: service_healthy
 
+  # ── Herd Dashboard (our custom UI) ────────
   dashboard:
     build:
       context: ./dashboard
       dockerfile: Dockerfile
     ports:
-      - "3000:3000"
+      - "3001:3000"
     environment:
       - NEXT_PUBLIC_API_URL=http://api:8000
     depends_on:
       - api
+
+  # ── Langfuse — LLM Observability ──────────
+  langfuse:
+    image: langfuse/langfuse:2
+    ports:
+      - "3002:3000"
+    environment:
+      DATABASE_URL: postgresql://langfuse:langfuse@langfuse-db:5432/langfuse
+      NEXTAUTH_URL: http://localhost:3002
+      NEXTAUTH_SECRET: ${LANGFUSE_NEXTAUTH_SECRET:-herd-langfuse-secret-change-me}
+      SALT: ${LANGFUSE_SALT:-herd-langfuse-salt-change-me}
+      TELEMETRY_ENABLED: "false"
+      LANGFUSE_ENABLE_EXPERIMENTAL_FEATURES: "false"
+    depends_on:
+      langfuse-db:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD", "wget", "-qO-", "http://localhost:3000/api/public/health"]
+      interval: 10s
+      timeout: 5s
+      retries: 10
+      start_period: 30s
+
+  langfuse-db:
+    image: postgres:16-alpine
+    environment:
+      POSTGRES_USER: langfuse
+      POSTGRES_PASSWORD: langfuse
+      POSTGRES_DB: langfuse
+    volumes:
+      - langfuse-db:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U langfuse"]
+      interval: 5s
+      timeout: 3s
+      retries: 10
+
+volumes:
+  langfuse-db:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,7 @@ dependencies = [
     "pyyaml>=6.0.2",
     "httpx>=0.28.0",
     "litellm>=1.52.0",
+    "agentops>=0.4.0",
 ]
 
 [project.optional-dependencies]

--- a/src/api/app.py
+++ b/src/api/app.py
@@ -12,10 +12,12 @@ from src.api.deps import set_db
 from src.api.routes import dashboard, jobs, proposals
 from src.core.config import load_config
 from src.core.db import Database
+from src.core.observability import init_observability
 
 
 @asynccontextmanager
 async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
+    init_observability()
     config = load_config()
     db_path = config.database.url.replace("sqlite+aiosqlite:///", "")
     db = Database(db_path)

--- a/src/core/observability.py
+++ b/src/core/observability.py
@@ -1,0 +1,77 @@
+"""
+Observability bootstrap — Langfuse + AgentOps.
+
+Call init_observability() once at process startup (API lifespan or CLI entry
+point). After that every LiteLLM call is automatically traced to Langfuse and
+every CrewAI agent run is automatically traced to AgentOps.
+
+Environment variables (all optional — observability degrades gracefully):
+    LANGFUSE_PUBLIC_KEY   Langfuse project public key
+    LANGFUSE_SECRET_KEY   Langfuse project secret key
+    LANGFUSE_HOST         Self-hosted URL (default: https://cloud.langfuse.com)
+    AGENTOPS_API_KEY      AgentOps project API key
+"""
+from __future__ import annotations
+
+import logging
+import os
+
+logger = logging.getLogger(__name__)
+
+
+def init_observability() -> None:
+    """Initialise Langfuse (via LiteLLM callback) and AgentOps."""
+    _init_langfuse()
+    _init_agentops()
+
+
+def _init_langfuse() -> None:
+    """
+    Register Langfuse as a LiteLLM success/failure callback.
+
+    LiteLLM reads LANGFUSE_PUBLIC_KEY, LANGFUSE_SECRET_KEY, and
+    LANGFUSE_HOST automatically — no further config needed here.
+    All acompletion() calls across every department will be traced.
+    """
+    public_key = os.environ.get("LANGFUSE_PUBLIC_KEY")
+    if not public_key:
+        logger.info("Langfuse disabled — set LANGFUSE_PUBLIC_KEY to enable")
+        return
+
+    try:
+        import litellm
+
+        if "langfuse" not in litellm.success_callback:
+            litellm.success_callback.append("langfuse")
+        if "langfuse" not in litellm.failure_callback:
+            litellm.failure_callback.append("langfuse")
+
+        host = os.environ.get("LANGFUSE_HOST", "https://cloud.langfuse.com")
+        logger.info("Langfuse enabled — tracing all LLM calls → %s", host)
+    except Exception:
+        logger.exception("Failed to initialise Langfuse")
+
+
+def _init_agentops() -> None:
+    """
+    Initialise AgentOps for CrewAI agent tracing.
+
+    AgentOps auto-instruments CrewAI once init() is called — no changes
+    needed in individual crew files.
+    """
+    api_key = os.environ.get("AGENTOPS_API_KEY")
+    if not api_key:
+        logger.info("AgentOps disabled — set AGENTOPS_API_KEY to enable")
+        return
+
+    try:
+        import agentops
+
+        agentops.init(
+            api_key=api_key,
+            default_tags=["herd-ai", "crewai"],
+            auto_start_session=True,
+        )
+        logger.info("AgentOps enabled — tracing CrewAI agent runs")
+    except Exception:
+        logger.exception("Failed to initialise AgentOps")


### PR DESCRIPTION
## Summary
- **Langfuse** (self-hosted, port 3002): registers as LiteLLM callback → all `acompletion()` calls project-wide are traced automatically, zero changes needed in individual departments
- **AgentOps** (cloud): `agentops.init()` auto-instruments every CrewAI crew for agent-level tracing
- Both integrations degrade gracefully when env vars are absent (log info, return early)
- Docker Compose: added `langfuse` + `langfuse-db` (Postgres) services with health checks

## Setup
1. `docker compose up langfuse langfuse-db` → open http://localhost:3002
2. Create account → Settings → API Keys → paste into `.env`
3. Sign up at https://app.agentops.ai → copy key → paste `AGENTOPS_API_KEY` in `.env`

## Test plan
- [ ] `docker compose up` starts cleanly with langfuse healthy before api
- [ ] LLM calls appear as traces in Langfuse UI at http://localhost:3002
- [ ] CrewAI runs appear as sessions in AgentOps dashboard
- [ ] Missing env vars produce info logs only, no crashes

🤖 Generated with [Claude Code](https://claude.com/claude-code)